### PR TITLE
Multi authoryearkey fix

### DIFF
--- a/ancientmetagenome-anthropogenic/README.md
+++ b/ancientmetagenome-anthropogenic/README.md
@@ -36,6 +36,7 @@ Sample columns are as follows:
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
 - If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
   - The already existing key does not need to be updated. `a` indicates the 'second' key added.
+  - e.g. Muhlemann2018 (original), Muhlemann2018a (first duplicate), Muhlemann2018b (second duplicate) etc.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientmetagenome-anthropogenic/README.md
+++ b/ancientmetagenome-anthropogenic/README.md
@@ -34,6 +34,8 @@ Sample columns are as follows:
   accents cannot be used**.
   - Use the non-accented version.
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
+- If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
+  - The already existing key does not need to be updated. `a` indicates the 'second' key added.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientmetagenome-anthropogenic/ancientmetagenome-anthropogenic_schema.json
+++ b/ancientmetagenome-anthropogenic/ancientmetagenome-anthropogenic_schema.json
@@ -31,11 +31,13 @@
             "project_name": {
                 "$id": "#/items/properties/project_name",
                 "type": "string",
-                "title": "Name of the project",
-                "description": "Format: surnameYYYY",
-                "pattern": "^[a-zA-Z]+\\d+$",
+                "title": "AncientMetagenomeDir key of the publication",
+                "description": "Format: surnameYYYY (if duplicate key but different publication, add a,b,c etc. as necessary)",
+                "pattern": "^[a-zA-Z]+\\d{4}[a-z]?$",
                 "examples": [
-                    "Warinner2014"
+                    "Warinner2014",
+                    "Muhlemann2018",
+                    "Muhlemann2018a"
                 ]
             },
             "publication_year": {

--- a/ancientmetagenome-environmental/README.md
+++ b/ancientmetagenome-environmental/README.md
@@ -32,6 +32,8 @@ Sample columns are as follows:
   accents cannot be used**.
   - Use the non-accented version.
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
+- If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
+  - The already existing key does not need to be updated. `a` indicates the 'second' key added.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientmetagenome-environmental/README.md
+++ b/ancientmetagenome-environmental/README.md
@@ -34,6 +34,7 @@ Sample columns are as follows:
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
 - If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
   - The already existing key does not need to be updated. `a` indicates the 'second' key added.
+  - e.g. Muhlemann2018 (original), Muhlemann2018a (first duplicate), Muhlemann2018b (second duplicate) etc.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientmetagenome-environmental/ancientmetagenome-environmental_schema.json
+++ b/ancientmetagenome-environmental/ancientmetagenome-environmental_schema.json
@@ -31,11 +31,13 @@
             "project_name": {
                 "$id": "#/items/properties/project_name",
                 "type": "string",
-                "title": "Name of the project",
-                "description": "Format: surnameYYYY",
-                "pattern": "^[a-zA-Z]+\\d+$",
+                "title": "AncientMetagenomeDir key of the publication",
+                "description": "Format: surnameYYYY (if duplicate key but different publication, add a,b,c etc. as necessary)",
+                "pattern": "^[a-zA-Z]+\\d{4}[a-z]?$",
                 "examples": [
-                    "Warinner2014"
+                    "Warinner2014",
+                    "Muhlemann2018",
+                    "Muhlemann2018a"
                 ]
             },
             "publication_year": {

--- a/ancientmetagenome-hostassociated/README.md
+++ b/ancientmetagenome-hostassociated/README.md
@@ -42,6 +42,7 @@ Sample columns are as follows:
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
 - If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
   - The already existing key does not need to be updated. `a` indicates the 'second' key added.
+  - e.g. Muhlemann2018 (original), Muhlemann2018a (first duplicate), Muhlemann2018b (second duplicate) etc.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientmetagenome-hostassociated/README.md
+++ b/ancientmetagenome-hostassociated/README.md
@@ -40,6 +40,8 @@ Sample columns are as follows:
   accents cannot be used**.
   - Use the non-accented version.
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
+- If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
+  - The already existing key does not need to be updated. `a` indicates the 'second' key added.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientmetagenome-hostassociated/ancientmetagenome-hostassociated_schema.json
+++ b/ancientmetagenome-hostassociated/ancientmetagenome-hostassociated_schema.json
@@ -33,11 +33,13 @@
             "project_name": {
                 "$id": "#/items/properties/project_name",
                 "type": "string",
-                "title": "Name of the project",
-                "description": "Format: surnameYYYY",
-                "pattern": "^[a-zA-Z]+\\d+$",
+                "title": "AncientMetagenomeDir key of the publication",
+                "description": "Format: surnameYYYY (if duplicate key but different publication, add a,b,c etc. as necessary)",
+                "pattern": "^[a-zA-Z]+\\d{4}[a-z]?$",
                 "examples": [
-                    "Warinner2014"
+                    "Warinner2014",
+                    "Muhlemann2018",
+                    "Muhlemann2018a"
                 ]
             },
             "publication_year": {

--- a/ancientsinglegenome-hostassociated/README.md
+++ b/ancientsinglegenome-hostassociated/README.md
@@ -33,6 +33,9 @@ Sample columns are as follows:
   accents cannot be used**.
   - Use the non-accented version.
   - If the first author has multiple or hyphenated surnames,  write them all together capitalising each surname.
+- If a same author/year combination already exists, please append a single lower case character (a,b,c) to the key. 
+  - The already existing key does not need to be updated. `a` indicates the 'second' key added.
+  - e.g. Muhlemann2018 (original), Muhlemann2018a (first duplicate), Muhlemann2018b (second duplicate) etc.
 
 > :warning: [MIxS v5](https://gensc.org/mixs/) compliant field  
 

--- a/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
+++ b/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
@@ -34,11 +34,13 @@
             "project_name": {
                 "$id": "#/items/properties/project_name",
                 "type": "string",
-                "title": "Name of the project",
-                "description": "Format: surnameYYYY",
-                "pattern": "^[a-zA-Z]+\\d+$",
+                "title": "AncientMetagenomeDir key of the publication",
+                "description": "Format: surnameYYYY (if duplicate key but different publication, add a,b,c etc. as necessary)",
+                "pattern": "^[a-zA-Z]+\\d{4}[a-z]?$",
                 "examples": [
-                    "Warinner2014"
+                    "Warinner2014",
+                    "Muhlemann2018",
+                    "Muhlemann2018a"
                 ]
             },
             "publication_year": {


### PR DESCRIPTION
# Pull Request

This PR addresses a case where an author (or authors with the same surname) may have submitted two papers in the same year.

For example:

#41 and #45 which are both Mühlemann 2018 but one in PNAS and one in Nature.

Changes are to the regex to allow e.g. `a` after the year of the added 'duplicate'.