### PR TITLE
Add new column for single-genome

### DIFF
--- a/ancientsinglegenome-hostassociated/README.md
+++ b/ancientsinglegenome-hostassociated/README.md
@@ -179,6 +179,27 @@ Sample columns are as follows:
 
 > :warning: Mandatory value  
 
+## data_type
+
+- The type of data avaliable under sample accession
+  - In some cases researchers are unable to upload raw data, or upload a combination of types
+  - This field indicates what type of data are avaliable by the uploaded accession
+  - Can include combinations (in comma separated list), but use single upper-level accessions where possible (e.g. ERS/SRS codes, which can be used when searching on the ENA to direct you to both raw files and genbank entries)
+  - If only lower down accession are avalible, this is acceptable (e.g. NCBI GenBank accessions for consensus)
+
+> :warning: Must follow categories specific in `assets/enums/<column>.json
+
+Definitions of possible categories are as follows:
+
+- `raw`: shotgun or whole-genome-enrichment data in FASTQ format without any type of depletion or computational manipulation of read/data composition, with exception of adapters being trimmed (as per ENA submission specifications).
+- `assembly`: anything that is derived of a de-novo assembly process, independent of the completeness.
+- `binned_mag`: a single-taxon assembly (derived from above) based on one or more binned metagenomes that meet certain quality requirements, and can be assumed to represent contigs from one bin of a metagenome.
+- `binned_cag`: reads recruited by ancient co-abundant genes.
+- `reference_aligned:` target reads derived from alignment (mapping) of metagenomic data to a reference sequence. Typically uploaded in BAM format without unmapped reads.
+- `consensus`: Any sequence derived from a consensus calling algorithm applied to `reference_aligned` data (typically a FASTA style file, as can be found on e.g. NCBI GenBank).
+
+For example, if only a consensus is avaliable from GenBank, this can be given the archive_accesion as: `MG585269.1`
+
 ## archive_accession
 
 - Of *sample*, where possible

--- a/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated.tsv
+++ b/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated.tsv
@@ -1,70 +1,70 @@
-project_name	publication_year	publication_doi	site_name	latitude	longitude	geo_loc_name	sample_name	sample_host	sample_age	sample_age_doi	singlegenome_domain	singlegenome_species	material	collection_date	archive	archive_accession
-Schuenemann2013	2013	10.1126/science.1238286	Sigtuna	59.618	17.726	Sweden	3077	Homo sapiens	900	10.1126/science.1238286	bacteria	Mycobacterium leprae	bone	NA	SRA	SRS418834
-Schuenemann2013	2013	10.1126/science.1238286	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_625	Homo sapiens	700	10.1126/science.1238286	bacteria	Mycobacterium leprae	tooth	NA	SRA	SRS418854
-Schuenemann2013	2013	10.1126/science.1238286	Refshale	56.193	9.394	Denmark	Refshale_16	Homo sapiens	900	10.1126/science.1238286	bacteria	Mycobacterium leprae	tooth	NA	SRA	SRS419262,SRS418858,SRS418859
-Schuenemann2013	2013	10.1126/science.1238286	St. Mary Magdalene leprosarium, Winchester	51.059	-1.308	United Kingdom	SK2	Homo sapiens	700	10.1126/science.1238286	bacteria	Mycobacterium leprae	bone	NA	SRA	SRS418843
-Schuenemann2013	2013	10.1126/science.1238286	St. Mary Magdalene leprosarium, Winchester	52.059	-1.308	United Kingdom	SK8	Homo sapiens	900	10.1126/science.1238286	bacteria	Mycobacterium leprae	tooth	NA	SRA	SRS418845
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_404	Homo sapiens	700	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	ERS1574247
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_427	Homo sapiens	800	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	ERS1574249
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_507	Homo sapiens	800	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	ERS1574253
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_533	Homo sapiens	900	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	ERS1574254
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_722	Homo sapiens	700	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	ERS1574259
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_749	Homo sapiens	700	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	ERS1574262
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Szentes-Kistőke	46.715	20.281	Hungary	SK11	Homo sapiens	1300	10.1016/j.meegid.2015.02.001	bacteria	Mycobacterium leprae	bone	NA	SRA	SRS2667046
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Necropoli Vicenne Campochiaro	41.564	14.498	Italy	T18	Homo sapiens	1300	10.1016/j.meegid.2015.02.001	bacteria	Mycobacterium leprae	bone	NA	SRA	SRS2667044
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Prušánky	48.831	16.982	Czech Republic	Body 188	Homo sapiens	1100	10.1016/j.meegid.2015.02.001	bacteria	Mycobacterium leprae	bone	NA	SRA	SRS2667047
-Schuenemann2018	2018	10.1371/journal.ppat.1006997	Great Chesterford	52.063	0.193	United Kingdom	GC96	Homo sapiens	1500	10.1371/journal.pone.0124282	bacteria	Mycobacterium leprae	bone	NA	SRA	SRS2667045
-Warinner2014	2014	10.1038/ng.2906	Dalheim	51.565	8.84	Germany	G12	Homo sapiens	900	10.1038/ng.2906	bacteria	Tannerella forsythia	tooth	NA	SRA	SRS473747,SRS473746,SRS473748,SRS473749,SRS473750
-Bos2014	2014	10.1038/nature13591	El Yaral	-17.41	-71.092	Peru	64	Homo sapiens	700	10.1038/nature13591	bacteria	Mycobacterium pinnipedii	bone	NA	SRA	SRS592075
-Bos2014	2014	10.1038/nature13591	El Algodonal	-17.583	-71.21	Peru	58	Homo sapiens	800	10.1038/nature13591	bacteria	Mycobacterium pinnipedii	bone	NA	SRA	SRS591992
-Bos2014	2014	10.1038/nature13591	Chiribaya Alta	-17.621	-71.269	Peru	54	Homo sapiens	800	10.1038/nature13591	bacteria	Mycobacterium pinnipedii	bone	NA	SRA	SRS591994
-AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Rasshevatskiy	45.569	41.03	Russia	RK1001	Homo sapiens	4700	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	ERS1892069
-AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Beli Manastir-Popova zemlja	45.77	18.61	Croatia	GEN72	Homo sapiens	4700	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	ERS1892068
-AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Gyvakarai	55.913	24.89	Lithuania	Gyvakarai1	Homo sapiens	4500	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	ERS1892064
-AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Kunila	58.616	23.796	Estonia	KunilaII	Homo sapiens	4400	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	ERS1892065
-AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Haunstetten Unterer Talweg 85	48.318	10.891	Germany	1343UnTal85	Homo sapiens	4200	10.1371/journal.pone.0139705	bacteria	Yersinia pestis	tooth	NA	ENA	ERS1892067
-AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Haunstetten Postillionstrasse 6	48.308	10.893	Germany	6Post	Homo sapiens	3900	10.1371/journal.pone.0139705	bacteria	Yersinia pestis	tooth	NA	ENA	ERS1892066
-Spyrou2018	2018	10.1038/s41467-018-04550-9	Mikhailovsky II burial site	53.2	50.2	Russia	RT5	Homo sapiens	3800	10.1038/s41467-018-04550-9	bacteria	Yersinia pestis	tooth	NA	ENA	ERS2106903
-Spyrou2018	2018	10.1038/s41467-018-04550-9	Mikhailovsky II burial site	53.2	50.2	Russia	RT6	Homo sapiens	3800	10.1038/s41467-018-04550-9	bacteria	Yersinia pestis	tooth	NA	ENA	ERS2106904
-Rascovan2019	2019	10.1016/j.cell.2018.11.005	Gökhem 94:1, Frälsegården	58.173	13.407	Sweden	Gok2	Homo sapiens	4900	10.1016/j.cell.2018.11.005	bacteria	Yersinia pestis	tooth	NA	ENA	ERS434180
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Sope	59.408	27.026	Estonia	RISE00 	Homo sapiens	4400	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848971
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Chociwel	50.796	17.094	Poland	RISE139 	Homo sapiens	4000	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848972
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Bulanovo	52.453	55.16	Russia	RISE386 	Homo sapiens	4000	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848973
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Kapan	39.2	46.4	Armenia	RISE397 	Homo sapiens	2900	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848974
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Kytmanovo	53.456	85.447	Russia	RISE505 	Homo sapiens	3600	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848975
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Bateni	54.584	90.775	Russia	RISE509 	Homo sapiens	4800	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848976
-Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Bateni	54.584	90.775	Russia	RISE511 	Homo sapiens	4700	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	ERS848977
-Yu2020	2020	10.1016/j.cell.2020.04.037	Glazkovskoe Predmestie Site	52.279	104.251	Russia	GLZ001	Homo sapiens	4300	10.1016/j.cell.2020.04.037	bacteria	Yersinia pestis	tooth	NA	ENA	ERS4540520
-Yu2020	2020	10.1016/j.cell.2020.04.037	Glazkovskoe Predmestie Site	52.279	104.251	Russia	GLZ002	Homo sapiens	4400	10.1016/j.cell.2020.04.037	bacteria	Yersinia pestis	tooth	NA	ENA	ERS4540521
-Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod1	Homo sapiens	800	10.7554/eLife.20983	bacteria	Gardnerella vaginalis	calcified nodule	NA	SRA	SRS1779841,SRS1779840
-Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod1	Homo sapiens	800	10.7554/eLife.20983	bacteria	Staphylococcus saprophyticus	calcified nodule	NA	SRA	SRS1779841,SRS1779840
-Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod2	Homo sapiens	800	10.7554/eLife.20983	bacteria	Gardnerella vaginalis	calcified nodule	NA	SRA	SRS1779846,SRS1779844
-Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod2	Homo sapiens	800	10.7554/eLife.20983	bacteria	Staphylococcus saprophyticus	calcified nodule	NA	SRA	SRS1779846,SRS1779844
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Bulanovo	52.453	55.16	Russia	RISE387	Homo sapiens	4200	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	ERS2295393
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Sandorfalva-Eperjes	46.344	20.162	Hungary	DA195	Homo sapiens	2500	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	ERS2295388
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Osterhofen-Altenmarkt	48.691	13.061	Germany	RISE563	Homo sapiens	4400	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	ERS2295394
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Szàzhalombatta-Földvàr	47.372	18.962	Hungary	RISE254	Homo sapiens	3900	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	bone	NA	ENA	ERS2295391
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Karasyur	46.997	66.285	Kazakhstan	DA29	Homo sapiens	800	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	ERS2295384
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Halvay 3	52.836	62.893	Kazakhstan	DA27	Homo sapiens	1600	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	ERS2295383
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Poprad	49.077	20.317	Slovakia	DA119	Homo sapiens	1500	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	ERS2295387
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Omnogobi	42.525	105.18	Mongolia	DA45	Homo sapiens	2100	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	bone	NA	ENA	ERS2295385
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Szczepankowice	50.948	16.943	Poland	RISE154	Homo sapiens	3800	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	ERS2295390
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Keden	41.428	75.329	Kyrgyzstan	DA51	Homo sapiens	2200	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	ERS2295386
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Bulanovo	52.453	55.16	Russia	RISE386	Homo sapiens	4100	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	ERS2295392
-Muhlemann2018	2018	10.1038/s41586-018-0097-z	Butakty	43.202	76.981	Kazakhstan	DA222	Homo sapiens	1100	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	ERS2295389
-Dux2020	2020	10.1126/science.aba9411	Berlin	52.51	13.4	Germany	BMM 655/1912	Homo sapiens	100	10.1126/science.aba9411	virus	Measles morbillivirus	lung tissue	NA	ENA	ERS4249335
-Dux2020	2020	10.1126/science.aba9411	Prague	50.06	14.46	Czech Republic	MVi/Prague.CZE/60/1	Homo sapiens	100	10.1126/science.aba9411	virus	Measles morbillivirus	isolate	NA	ENA	ERS4249362
-Dux2020	2020	10.1126/science.aba9411	Prague	50.06	14.46	Czech Republic	Mvi/Prague.CZE/60/2	Homo sapiens	100	10.1126/science.aba9411	virus	Measles morbillivirus	isolate	NA	ENA	ERS4249363
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach corpus, content I 1054	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	ERS942275,ERS942266,ERS942283,ERS942284,ERS942285,ERS942286,ERS942287,ERS942288,ERS942289,ERS942290,ERS942291,ERS942291,ERS942292,ERS942292,ERS942293,ERS942293,ERS942294,ERS942294,
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach corpus, content II 1054	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	ERS942267,ERS942277
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach corpus, surface 1054	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	ERS942270,ERS942274,ERS942269
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach antrum, content 1051	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	ERS942268,ERS942271
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach antrum, surface 1051	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	ERS942265,ERS942273
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Small intestine 1063	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	NA	ENA	ERS942272
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Large intestine, upper part I 1036	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	NA	ENA	ERS942281
-Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Large intestine, upper part II 1036	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	NA	ENA	ERS942282
-Guellil2018	2018	10.1073/pnas.1807266115	St Nicolay’s ALT St Clement's Church, Oslo 	59.904	10.765	Norway	OSL9a	Homo sapiens	500	10.1073/pnas.1807266115	bacteria	Borrelia recurrentis	tooth	NA	ENA	ERS2591211
-Guellil2018	2018	10.1073/pnas.1807266115	St Nicolay’s ALT St Clement's Church, Oslo 	59.904	10.765	Norway	OSL9b	Homo sapiens	500	10.1073/pnas.1807266116	bacteria	Borrelia recurrentis	tooth	NA	ENA	ERS2591210
-Duggan2016	2016	10.1016/j.cub.2016.10.061	Dominican Church of the Holy Spirit of Vilnius	54.681	25.284	Lithuania	VD21	Homo sapiens	400	10.1016/j.cub.2016.10.061	virus	Variola virus	skin	2011	SRA	SRS1749354
-deBarrosDamgaard2018	2018	10.1038/s41586-018-0094-2	Uch-Kurbu	42.159	77.406	Kyrgyzstan	DA101	Homo sapiens	1700	10.1038/s41586-018-0094-2	bacteria	Yersinia pestis	tooth	NA	ENA	ERS2367268
-deBarrosDamgaard2018	2018	10.1038/s41586-018-0094-2	Unknown	42.861	44.185	Russia	DA147	Homo sapiens	1300	10.1038/s41586-018-0094-2	bacteria	Yersinia pestis	tooth	NA	ENA	ERS2367269
+project_name	publication_year	publication_doi	site_name	latitude	longitude	geo_loc_name	sample_name	sample_host	sample_age	sample_age_doi	singlegenome_domain	singlegenome_species	material	collection_date	archive	data_type	archive_accession
+Schuenemann2013	2013	10.1126/science.1238286	Sigtuna	59.618	17.726	Sweden	3077	Homo sapiens	900	10.1126/science.1238286	bacteria	Mycobacterium leprae	bone	NA	SRA	raw	SRS418834
+Schuenemann2013	2013	10.1126/science.1238286	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_625	Homo sapiens	700	10.1126/science.1238286	bacteria	Mycobacterium leprae	tooth	NA	SRA	raw	SRS418854
+Schuenemann2013	2013	10.1126/science.1238286	Refshale	56.193	9.394	Denmark	Refshale_16	Homo sapiens	900	10.1126/science.1238286	bacteria	Mycobacterium leprae	tooth	NA	SRA	raw	SRS419262,SRS418858,SRS418859
+Schuenemann2013	2013	10.1126/science.1238286	St. Mary Magdalene leprosarium, Winchester	51.059	-1.308	United Kingdom	SK2	Homo sapiens	700	10.1126/science.1238286	bacteria	Mycobacterium leprae	bone	NA	SRA	raw	SRS418843
+Schuenemann2013	2013	10.1126/science.1238286	St. Mary Magdalene leprosarium, Winchester	52.059	-1.308	United Kingdom	SK8	Homo sapiens	900	10.1126/science.1238286	bacteria	Mycobacterium leprae	tooth	NA	SRA	raw	SRS418845
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_404	Homo sapiens	700	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	raw	ERS1574247
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_427	Homo sapiens	800	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	raw	ERS1574249
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_507	Homo sapiens	800	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	raw	ERS1574253
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_533	Homo sapiens	900	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	raw	ERS1574254
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_722	Homo sapiens	700	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	raw	ERS1574259
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Odense St. Jørgen cemetery	55.399	10.406	Denmark	Jorgen_749	Homo sapiens	700	10.1371/journal.ppat.1006997	bacteria	Mycobacterium leprae	tooth	NA	ENA	raw	ERS1574262
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Szentes-Kistőke	46.715	20.281	Hungary	SK11	Homo sapiens	1300	10.1016/j.meegid.2015.02.001	bacteria	Mycobacterium leprae	bone	NA	SRA	raw	SRS2667046
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Necropoli Vicenne Campochiaro	41.564	14.498	Italy	T18	Homo sapiens	1300	10.1016/j.meegid.2015.02.001	bacteria	Mycobacterium leprae	bone	NA	SRA	raw	SRS2667044
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Prušánky	48.831	16.982	Czech Republic	Body 188	Homo sapiens	1100	10.1016/j.meegid.2015.02.001	bacteria	Mycobacterium leprae	bone	NA	SRA	raw	SRS2667047
+Schuenemann2018	2018	10.1371/journal.ppat.1006997	Great Chesterford	52.063	0.193	United Kingdom	GC96	Homo sapiens	1500	10.1371/journal.pone.0124282	bacteria	Mycobacterium leprae	bone	NA	SRA	raw	SRS2667045
+Warinner2014	2014	10.1038/ng.2906	Dalheim	51.565	8.84	Germany	G12	Homo sapiens	900	10.1038/ng.2906	bacteria	Tannerella forsythia	tooth	NA	SRA	raw	SRS473747,SRS473746,SRS473748,SRS473749,SRS473750
+Bos2014	2014	10.1038/nature13591	El Yaral	-17.41	-71.092	Peru	64	Homo sapiens	700	10.1038/nature13591	bacteria	Mycobacterium pinnipedii	bone	NA	SRA	raw	SRS592075
+Bos2014	2014	10.1038/nature13591	El Algodonal	-17.583	-71.21	Peru	58	Homo sapiens	800	10.1038/nature13591	bacteria	Mycobacterium pinnipedii	bone	NA	SRA	raw	SRS591992
+Bos2014	2014	10.1038/nature13591	Chiribaya Alta	-17.621	-71.269	Peru	54	Homo sapiens	800	10.1038/nature13591	bacteria	Mycobacterium pinnipedii	bone	NA	SRA	raw	SRS591994
+AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Rasshevatskiy	45.569	41.03	Russia	RK1001	Homo sapiens	4700	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS1892069
+AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Beli Manastir-Popova zemlja	45.77	18.61	Croatia	GEN72	Homo sapiens	4700	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS1892068
+AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Gyvakarai	55.913	24.89	Lithuania	Gyvakarai1	Homo sapiens	4500	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS1892064
+AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Kunila	58.616	23.796	Estonia	KunilaII	Homo sapiens	4400	10.1016/j.cub.2017.10.025	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS1892065
+AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Haunstetten Unterer Talweg 85	48.318	10.891	Germany	1343UnTal85	Homo sapiens	4200	10.1371/journal.pone.0139705	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS1892067
+AndradesValtuena2017	2017	10.1016/j.cub.2017.10.025	Haunstetten Postillionstrasse 6	48.308	10.893	Germany	6Post	Homo sapiens	3900	10.1371/journal.pone.0139705	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS1892066
+Spyrou2018	2018	10.1038/s41467-018-04550-9	Mikhailovsky II burial site	53.2	50.2	Russia	RT5	Homo sapiens	3800	10.1038/s41467-018-04550-9	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS2106903
+Spyrou2018	2018	10.1038/s41467-018-04550-9	Mikhailovsky II burial site	53.2	50.2	Russia	RT6	Homo sapiens	3800	10.1038/s41467-018-04550-9	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS2106904
+Rascovan2019	2019	10.1016/j.cell.2018.11.005	Gökhem 94:1, Frälsegården	58.173	13.407	Sweden	Gok2	Homo sapiens	4900	10.1016/j.cell.2018.11.005	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS434180
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Sope	59.408	27.026	Estonia	RISE00 	Homo sapiens	4400	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848971
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Chociwel	50.796	17.094	Poland	RISE139 	Homo sapiens	4000	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848972
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Bulanovo	52.453	55.16	Russia	RISE386 	Homo sapiens	4000	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848973
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Kapan	39.2	46.4	Armenia	RISE397 	Homo sapiens	2900	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848974
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Kytmanovo	53.456	85.447	Russia	RISE505 	Homo sapiens	3600	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848975
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Bateni	54.584	90.775	Russia	RISE509 	Homo sapiens	4800	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848976
+Rasmussen2015	2015	10.1016/j.cell.2015.10.009	Bateni	54.584	90.775	Russia	RISE511 	Homo sapiens	4700	10.1038/nature14507	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS848977
+Yu2020	2020	10.1016/j.cell.2020.04.037	Glazkovskoe Predmestie Site	52.279	104.251	Russia	GLZ001	Homo sapiens	4300	10.1016/j.cell.2020.04.037	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS4540520
+Yu2020	2020	10.1016/j.cell.2020.04.037	Glazkovskoe Predmestie Site	52.279	104.251	Russia	GLZ002	Homo sapiens	4400	10.1016/j.cell.2020.04.037	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS4540521
+Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod1	Homo sapiens	800	10.7554/eLife.20983	bacteria	Gardnerella vaginalis	calcified nodule	NA	SRA	raw	SRS1779841,SRS1779840
+Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod1	Homo sapiens	800	10.7554/eLife.20983	bacteria	Staphylococcus saprophyticus	calcified nodule	NA	SRA	raw	SRS1779841,SRS1779840
+Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod2	Homo sapiens	800	10.7554/eLife.20983	bacteria	Gardnerella vaginalis	calcified nodule	NA	SRA	raw	SRS1779846,SRS1779844
+Devault2017	2017	10.7554/eLife.20983	Troy	39.953	26.236	Turkey	Nod2	Homo sapiens	800	10.7554/eLife.20983	bacteria	Staphylococcus saprophyticus	calcified nodule	NA	SRA	raw	SRS1779846,SRS1779844
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Bulanovo	52.453	55.16	Russia	RISE387	Homo sapiens	4200	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	raw	ERS2295393
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Sandorfalva-Eperjes	46.344	20.162	Hungary	DA195	Homo sapiens	2500	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	raw	ERS2295388
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Osterhofen-Altenmarkt	48.691	13.061	Germany	RISE563	Homo sapiens	4400	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	raw	ERS2295394
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Szàzhalombatta-Földvàr	47.372	18.962	Hungary	RISE254	Homo sapiens	3900	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	bone	NA	ENA	raw	ERS2295391
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Karasyur	46.997	66.285	Kazakhstan	DA29	Homo sapiens	800	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	raw	ERS2295384
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Halvay 3	52.836	62.893	Kazakhstan	DA27	Homo sapiens	1600	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	raw	ERS2295383
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Poprad	49.077	20.317	Slovakia	DA119	Homo sapiens	1500	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	raw	ERS2295387
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Omnogobi	42.525	105.18	Mongolia	DA45	Homo sapiens	2100	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	bone	NA	ENA	raw	ERS2295385
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Szczepankowice	50.948	16.943	Poland	RISE154	Homo sapiens	3800	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	raw	ERS2295390
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Keden	41.428	75.329	Kyrgyzstan	DA51	Homo sapiens	2200	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	raw	ERS2295386
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Bulanovo	52.453	55.16	Russia	RISE386	Homo sapiens	4100	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	tooth	NA	ENA	raw	ERS2295392
+Muhlemann2018	2018	10.1038/s41586-018-0097-z	Butakty	43.202	76.981	Kazakhstan	DA222	Homo sapiens	1100	10.1038/s41586-018-0097-z	virus	Hepatitis B virus	unknown	NA	ENA	raw	ERS2295389
+Dux2020	2020	10.1126/science.aba9411	Berlin	52.51	13.4	Germany	BMM 655/1912	Homo sapiens	100	10.1126/science.aba9411	virus	Measles morbillivirus	lung tissue	NA	ENA	raw	ERS4249335
+Dux2020	2020	10.1126/science.aba9411	Prague	50.06	14.46	Czech Republic	MVi/Prague.CZE/60/1	Homo sapiens	100	10.1126/science.aba9411	virus	Measles morbillivirus	isolate	NA	ENA	raw	ERS4249362
+Dux2020	2020	10.1126/science.aba9411	Prague	50.06	14.46	Czech Republic	Mvi/Prague.CZE/60/2	Homo sapiens	100	10.1126/science.aba9411	virus	Measles morbillivirus	isolate	NA	ENA	raw	ERS4249363
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach corpus, content I 1054	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	raw	ERS942275,ERS942266,ERS942283,ERS942284,ERS942285,ERS942286,ERS942287,ERS942288,ERS942289,ERS942290,ERS942291,ERS942291,ERS942292,ERS942292,ERS942293,ERS942293,ERS942294,ERS942294,
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach corpus, content II 1054	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	raw	ERS942267,ERS942277
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach corpus, surface 1054	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	raw	ERS942270,ERS942274,ERS942269
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach antrum, content 1051	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	raw	ERS942268,ERS942271
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Stomach antrum, surface 1051	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	2010	ENA	raw	ERS942265,ERS942273
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Small intestine 1063	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	NA	ENA	raw	ERS942272
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Large intestine, upper part I 1036	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	NA	ENA	raw	ERS942281
+Maixner2016	2016	10.1126/science.aad2545	Hauslabjoch	46.773	10.837	Italy	Iceman Large intestine, upper part II 1036	Homo sapiens	5300	10.1126/science.aad2545	virus	Helicobacter pylori	digestive tract contents	NA	ENA	raw	ERS942282
+Guellil2018	2018	10.1073/pnas.1807266115	St Nicolay’s ALT St Clement's Church, Oslo 	59.904	10.765	Norway	OSL9a	Homo sapiens	500	10.1073/pnas.1807266115	bacteria	Borrelia recurrentis	tooth	NA	ENA	raw	ERS2591211
+Guellil2018	2018	10.1073/pnas.1807266115	St Nicolay’s ALT St Clement's Church, Oslo 	59.904	10.765	Norway	OSL9b	Homo sapiens	500	10.1073/pnas.1807266116	bacteria	Borrelia recurrentis	tooth	NA	ENA	raw	ERS2591210
+Duggan2016	2016	10.1016/j.cub.2016.10.061	Dominican Church of the Holy Spirit of Vilnius	54.681	25.284	Lithuania	VD21	Homo sapiens	400	10.1016/j.cub.2016.10.061	virus	Variola virus	skin	2011	SRA	raw	SRS1749354
+deBarrosDamgaard2018	2018	10.1038/s41586-018-0094-2	Uch-Kurbu	42.159	77.406	Kyrgyzstan	DA101	Homo sapiens	1700	10.1038/s41586-018-0094-2	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS2367268
+deBarrosDamgaard2018	2018	10.1038/s41586-018-0094-2	Unknown	42.861	44.185	Russia	DA147	Homo sapiens	1300	10.1038/s41586-018-0094-2	bacteria	Yersinia pestis	tooth	NA	ENA	raw	ERS2367269

--- a/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
+++ b/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
@@ -206,6 +206,18 @@
                     "ENA"
                 ]
             },
+            "data_type": {
+                "$id": "#items/properties/data_type",
+                "type": "string",
+                "title": "Avaliable data types",
+                "description": "Types of accessible data via accession",
+                "$ref": "https://spaam-workshop.github.io/AncientMetagenomeDir/assets/enums/data_type.json",
+                "examples": [
+                    "raw",
+                    "consensus",
+                    "assembly,binned_mag"
+                ]
+            },
             "archive_accession": {
                 "$id": "#/items/properties/archive_accession",
                 "type": [

--- a/assets/enums/archive.json
+++ b/assets/enums/archive.json
@@ -4,6 +4,7 @@
         "SRA",
         "OAGR",
         "UCPH ERDA",
-        "MG-RAST"
+        "MG-RAST",
+        "GenBank"
     ]
 }

--- a/assets/enums/data_type.json
+++ b/assets/enums/data_type.json
@@ -1,0 +1,22 @@
+{
+  "enum": [
+    "raw",
+    "assembly",
+    "binned_mag",
+    "binned_cag",
+    "reference_aligned",
+    "consensus",
+    "raw,reference_aligned",
+    "raw,reference_aligned,consensus",
+    "raw,consensus",
+    "reference_aligned,consensus",
+    "raw,assembly",
+    "raw,assembly,binned_mag",
+    "raw,binned_mag",
+    "assembly,binned_mag",
+    "raw,binned_mag",
+    "raw,assembly,binned_cag",
+    "raw,binned_cag",
+    "assembly,binned_cag"
+  ]
+}


### PR DESCRIPTION
# Pull Request

Adds new column for single-genome hostassociated list to allow non-raw data sequences (e.g. when only consesnus sequence uploaded to GenBank).

Definitions are as originally described in the slack discussion.