### PR TITLE
Restrict Lat:Lon decimals with regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project follows to [Calendar Versioning](https://calver.org/).
 
 ### Changed
 - Ardelean 2020: Differentiated samples with identical names
+- Added regex to restrict Latitude and Longitude to maximum of three decimal places
 
 ## v20.09: Ancient Ksour of Ouadane
 

--- a/ancientmetagenome-anthropogenic/ancientmetagenome-anthropogenic_schema.json
+++ b/ancientmetagenome-anthropogenic/ancientmetagenome-anthropogenic_schema.json
@@ -76,6 +76,7 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -90,
                 "maximum": 90,
                 "title": "Latitude",
@@ -90,6 +91,7 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -180,
                 "maximum": 180,
                 "title": "Longitude",

--- a/ancientmetagenome-anthropogenic/ancientmetagenome-anthropogenic_schema.json
+++ b/ancientmetagenome-anthropogenic/ancientmetagenome-anthropogenic_schema.json
@@ -73,7 +73,7 @@
             "latitude": {
                 "$id": "#/items/properties/latitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
@@ -88,7 +88,7 @@
             "longitude": {
                 "$id": "#/items/properties/longitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",

--- a/ancientmetagenome-environmental/ancientmetagenome-environmental_schema.json
+++ b/ancientmetagenome-environmental/ancientmetagenome-environmental_schema.json
@@ -76,6 +76,7 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -90,
                 "maximum": 90,
                 "title": "Latitude",
@@ -90,6 +91,7 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -180,
                 "maximum": 180,
                 "title": "Longitude",

--- a/ancientmetagenome-environmental/ancientmetagenome-environmental_schema.json
+++ b/ancientmetagenome-environmental/ancientmetagenome-environmental_schema.json
@@ -73,7 +73,7 @@
             "latitude": {
                 "$id": "#/items/properties/latitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
@@ -88,7 +88,7 @@
             "longitude": {
                 "$id": "#/items/properties/longitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",

--- a/ancientmetagenome-hostassociated/ancientmetagenome-hostassociated_schema.json
+++ b/ancientmetagenome-hostassociated/ancientmetagenome-hostassociated_schema.json
@@ -78,10 +78,11 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -90,
                 "maximum": 90,
                 "title": "Latitude",
-                "description": "WGS 84 Latitude Ranges between -90 and 90 (e.g. as used in Google Maps)",
+                "description": "Ranges between -90 and 90",
                 "examples": [
                     51.565
                 ]
@@ -92,10 +93,11 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -180,
                 "maximum": 180,
                 "title": "Longitude",
-                "description": "WGS 84 Longitude Ranges between -180 and 180 (e.g. as used in Google Maps)",
+                "description": "Ranges between -180 and 180",
                 "examples": [
                     8.84
                 ]

--- a/ancientmetagenome-hostassociated/ancientmetagenome-hostassociated_schema.json
+++ b/ancientmetagenome-hostassociated/ancientmetagenome-hostassociated_schema.json
@@ -75,7 +75,7 @@
             "latitude": {
                 "$id": "#/items/properties/latitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
@@ -90,7 +90,7 @@
             "longitude": {
                 "$id": "#/items/properties/longitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",

--- a/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
+++ b/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
@@ -76,7 +76,7 @@
             "latitude": {
                 "$id": "#/items/properties/latitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
@@ -91,7 +91,7 @@
             "longitude": {
                 "$id": "#/items/properties/longitude",
                 "type": [
-                    "number",
+                    "string",
                     "null"
                 ],
                 "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",

--- a/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
+++ b/ancientsinglegenome-hostassociated/ancientsinglegenome-hostassociated_schema.json
@@ -79,10 +79,11 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -90,
                 "maximum": 90,
                 "title": "Latitude",
-                "description": "WGS 84 Latitude Ranges between -90 and 90 (e.g. as used in Google Maps)",
+                "description": "Ranges between -90 and 90",
                 "examples": [
                     51.565
                 ]
@@ -93,10 +94,11 @@
                     "number",
                     "null"
                 ],
+                "pattern": "^-?[0-9]+\\.[0-9]{0,3}$",
                 "minimum": -180,
                 "maximum": 180,
                 "title": "Longitude",
-                "description": "WGS 84 Longitude Ranges between -180 and 180 (e.g. as used in Google Maps)",
+                "description": "Ranges between -180 and 180",
                 "examples": [
                     8.84
                 ]


### PR DESCRIPTION
This PR adds extra regex for Lat:Lon to restrict the number of decimals (to prevent people giving overly specific coordinates that gives a false sense of certainty of the exact location).

To close #241 